### PR TITLE
refactor: chip away at removing eyre

### DIFF
--- a/sdk/rust/crates/dagger-sdk/src/core/engine.rs
+++ b/sdk/rust/crates/dagger-sdk/src/core/engine.rs
@@ -12,7 +12,7 @@ impl Engine {
     }
 
     async fn from_cli(&self, cfg: &Config) -> eyre::Result<(ConnectParams, tokio::process::Child)> {
-        let cli = Downloader::new(DAGGER_ENGINE_VERSION.into())?
+        let cli = Downloader::new(DAGGER_ENGINE_VERSION.into())
             .get_cli()
             .await?;
 

--- a/sdk/rust/crates/dagger-sdk/src/errors.rs
+++ b/sdk/rust/crates/dagger-sdk/src/errors.rs
@@ -16,6 +16,8 @@ pub enum DaggerError {
     Query(#[source] crate::core::graphql_client::GraphQLError),
     #[error("failed to unpack response")]
     Unpack(#[source] DaggerUnpackError),
+    #[error("failed to download client")]
+    DownloadClient(#[source] eyre::Error),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
The ambition is at some point to get eyre away entirely. It makes it difficult to get type safe errors. For the most part `DaggerError` is used, but internally we still rely on eyre. It should be gone